### PR TITLE
Add issue templates for bug reports, feature requests, and plugin reviews

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,64 @@
+name: Bug report
+description: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Describe the bug**
+        A clear and concise description of what the bug is.
+
+  - type: textarea
+    attributes:
+      label: Steps to reproduce
+      description: Steps to reproduce the behavior
+      value: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
+
+  - type: textarea
+    attributes:
+      label: Expected behavior
+      description: A clear and concise description of what you expected to happen.
+
+  - type: textarea
+    attributes:
+      label: Screenshots
+      description: If applicable, add screenshots to help explain your problem.
+
+  - type: input
+    attributes:
+      label: WordPress version
+      description: The version of WordPress you are using.
+
+  - type: input
+    attributes:
+      label: PHP version
+      description: The version of PHP you are using.
+
+  - type: input
+    attributes:
+      label: Desktop (please complete the following information)
+      description: |
+        - OS: [e.g. iOS]
+        - Browser [e.g. chrome, safari]
+        - Version [e.g. 22]
+
+  - type: input
+    attributes:
+      label: Smartphone (please complete the following information)
+      description: |
+        - Device: [e.g. iPhone6]
+        - OS: [e.g. iOS8.1]
+        - Browser [e.g. stock browser, safari]
+        - Version [e.g. 22]
+
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Seoul WordPress Meetup
+    url: https://seoul.wpmeetup.kr

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,21 @@
+name: Feature request
+description: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+body:
+  - type: textarea
+    attributes:
+      label: Feature description
+      description: A clear and concise description of the feature you are requesting.
+
+  - type: textarea
+    attributes:
+      label: Problem to solve
+      description: Describe the problem this feature will solve.
+
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/wp_plugin_review.yml
+++ b/.github/ISSUE_TEMPLATE/wp_plugin_review.yml
@@ -1,0 +1,23 @@
+name: WordPress Plugin Directory review
+description: Feedback on registering a WordPress plugin
+title: ''
+labels: ''
+assignees: ''
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **List of issues found**
+        - [ ] list of issues
+        - [ ] ...
+
+  - type: input
+    attributes:
+      label: Plugin version
+      description: The version of the plugin you are using.
+
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem here.


### PR DESCRIPTION
Related with #6

GitHub에서 제공하는 기본 양식을 활용하여 3가지 사례에 대한 이슈 템플릿을 추가했습니다.

활용 방식에 따라 적절히 내용을 수정해도 좋을 것 같습니다.